### PR TITLE
Padding for the right side avoid to split grapheme clusters

### DIFF
--- a/main.js
+++ b/main.js
@@ -16,11 +16,13 @@ const argv = minimist(process.argv.slice(2), {
 const run = (emoji, interval) => {
   let positions = []
   const startingLine = 3
+  const padding = 10
 
   setInterval(() => {
     const [column, line] = process.stdout.getWindowSize()
     const vanishingLine = line - 1
-    const printingColumn = Math.floor(Math.random() * column)
+    const maxPrintingColumn = column - padding
+    const printingColumn = Math.floor(Math.random() * maxPrintingColumn)
     console.clear()
 
     positions.push([printingColumn, startingLine])


### PR DESCRIPTION
## Issue

- https://github.com/sadanora/hiyoko-rain/issues/1

## 改善後の画像

<img width="748" alt="image" src="https://github.com/user-attachments/assets/3d398f53-2806-449c-9ffd-ccfb77171236">

## 詳細

書記素クラスタを分断して表示していたことが、絵文字が分裂していた原因でした。

解決法として、ターミナル右側のpaddingに余裕をもたせることで、絵文字の途中で折り返さないようにしました。

👨‍👩‍👦は7文字なので、10文字ぶんのpaddingがあればほとんどのケースに対応できるはず！という目論見です。

参考）https://blog.jxck.io/entries/2017-03-02/unicode-in-javascript.html#zwj

## 補足

もし与えられた絵文字によってpaddingの大きさを変化できれば、もっとスタイリッシュなコードになると思います！
